### PR TITLE
Add an on-parse callback parameter to vega directive.

### DIFF
--- a/src/ng-vega.js
+++ b/src/ng-vega.js
@@ -42,7 +42,8 @@
         scope: {
           spec: '=',
           data: '=vegaData',
-          renderer: '=vegaRenderer'
+          renderer: '=vegaRenderer',
+          onParse: '&vegaOnParse'
         },
         link: function(scope, elements, attrs) {
           var element = elements[0];
@@ -56,6 +57,7 @@
                 data: processedData,
                 renderer: scope.renderer || 'svg'
               }).update();
+              scope.onParse({view: view});
             });
           }
 


### PR DESCRIPTION
I have distilled my proposed enhancement down to an addition of two lines. Although it's a small change, it enables useful interaction possibilities that were not previously possible with `ng-vega`. By using this optional callback, the invoking Angular code will be notified when Vega has finished parsing the spec. In addition, the parameter to the callback (`view`) allows full access to Vega's View component API:

> https://github.com/vega/vega/wiki/Runtime#view-component-api

which includes event listeners (`view.on(...)`), which is what our project needs for visualizations that can interact with the rest of our Angular environment.

The change adds an optional `vega-on-parse` parameter to the `vega` directive which takes a callback function. The `onParse()` function is invoked within the Vega callback for `vg.parse.spec()`.

If this looks like it would be a good fit for `ng-vega`, I can work up an example to include and some documentation to add to the Usage section of the README. It was not immediately obvious to me how to run a build so that `dist/` would be updated with the changes, but I'd be happy to add that in as well if you wish to point me in the right direction there.
